### PR TITLE
Manta is also able to use "public" directory

### DIFF
--- a/http/client.go
+++ b/http/client.go
@@ -416,5 +416,5 @@ func handleError(URL string, resp *http.Response) error {
 }
 
 func isMantaRequest(url, user string) bool {
-	return strings.Contains(url, "/"+user+"/stor") || strings.Contains(url, "/"+user+"/jobs")
+	return strings.Contains(url, "/"+user+"/stor") || strings.Contains(url, "/"+user+"/jobs") || strings.Contains(url, "/"+user+"/public")
 }


### PR DESCRIPTION
- prior to this change, a manta request could only 
  access "stor" and "jobs" directory
