### PR TITLE
Remove dependency on juju/loggo in favor of stdlib

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -11,12 +11,11 @@ package client
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 	"sync"
 	"time"
-
-	"github.com/juju/loggo"
 
 	joyenthttp "github.com/joyent/gocommon/http"
 	"github.com/joyent/gosign/auth"
@@ -44,7 +43,7 @@ type Client interface {
 // This client sends requests without authenticating.
 type client struct {
 	mu         sync.Mutex
-	logger     *loggo.Logger
+	logger     *log.Logger
 	baseURL    string
 	creds      *auth.Credentials
 	httpClient *joyenthttp.Client
@@ -52,12 +51,12 @@ type client struct {
 
 var _ Client = (*client)(nil)
 
-func newClient(baseURL string, credentials *auth.Credentials, httpClient *joyenthttp.Client, logger *loggo.Logger) Client {
+func newClient(baseURL string, credentials *auth.Credentials, httpClient *joyenthttp.Client, logger *log.Logger) Client {
 	client := client{baseURL: baseURL, logger: logger, creds: credentials, httpClient: httpClient}
 	return &client
 }
 
-func NewClient(baseURL, apiVersion string, credentials *auth.Credentials, logger *loggo.Logger) Client {
+func NewClient(baseURL, apiVersion string, credentials *auth.Credentials, logger *log.Logger) Client {
 	sharedHttpClient := joyenthttp.New(credentials, apiVersion, logger)
 	return newClient(baseURL, credentials, sharedHttpClient, logger)
 }


### PR DESCRIPTION
This commit removes the dependency on GPLv3 package `juju/loggo` and instead prefers to depend on the standard library logger, which is easier to integrate into applications in any case.

In order to retain the functionality of (sort of) levelled logging, the `http.Client` struct now has a `SetTrace(bool)` method which will enable or disable printing of request traces. This is not thread safe, but if that is an issue it would be reasonably straightforward to synchronize access.

Tests looked to be failing prior to these edits with the `master` branch of dependencies - no new tests fail as a result of this.

Required for https://github.com/joyent/gocommon/issues/6 and https://github.com/hashicorp/terraform/pull/5277#issuecomment-198758723