### PR TITLE
Set up TLS for TestDefaultClientRejectSelfSigned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ _cgo_gotypes.go
 _cgo_export.*
 
 _testmain.go
+*.test
 
 *.exe
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ gocommon
 
 Common Go library for Joyent's Triton and Manta.
 
+[![wercker status](https://app.wercker.com/status/2f63bf7f68bfdd46b979abad19c0bee0/s/master "wercker status")](https://app.wercker.com/project/byKey/2f63bf7f68bfdd46b979abad19c0bee0)
+
 ## Installation
 
 Use `go-get` to install gocommon.
@@ -70,7 +72,20 @@ upstream        git@github.com:joyent/gocommon.git (push)
 
 ### Run Tests
 
+The library needs values for the `SDC_URL`, `MANTA_URL`, `MANTA_KEY_ID` and `SDC_KEY_ID` environment variables even though the tests are run locally. You can generate a temporary key and use its fingerprint for tests without adding the key to your Triton Cloud account.
+
 ```
+# create a temporary key
+ssh-keygen -b 2048 -C "Testing Key" -f /tmp/id_rsa -t rsa -P ""
+
+# set up environment
+# note: leave the -E md5 argument off on older ssh-keygen
+export KEY_ID=$(ssh-keygen -E md5 -lf /tmp/id_rsa | awk -F' ' '{print $2}' | cut -d':' -f2-)
+export SDC_KEY_ID=${KEY_ID}
+export MANTA_KEY_ID=${KEY_ID}
+export SDC_URL=https://us-east-1.api.joyent.com
+export MANTA_URL=https://us-east.manta.joyent.com
+
 cd ${GOPATH}/src/github.com/joyent/gocommon
 go test ./...
 ```

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -29,7 +29,7 @@ const (
 	RequestTooLargeError    = Code("RequestTooLarge")
 	RequestMovedError       = Code("RequestMoved")
 	ResourceNotFoundError   = Code("ResourceNotFound")
-	UnknownErrorError       = Code("UnkownError")
+	UnknownErrorError       = Code("UnknownError")
 )
 
 // Error instances store an optional error cause.

--- a/testing/httpsuite_test.go
+++ b/testing/httpsuite_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	jt "github.com/joyent/gocommon/testing"
+	"github.com/julienschmidt/httprouter"
 )
 
 type HTTPTestSuite struct {
@@ -28,16 +29,14 @@ func Test(t *testing.T) {
 var _ = gc.Suite(&HTTPTestSuite{})
 var _ = gc.Suite(&HTTPSTestSuite{jt.HTTPSuite{UseTLS: true}})
 
-type HelloHandler struct{}
-
-func (h *HelloHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+func HelloHandler(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	w.Header().Set("Content-Type", "text/plain")
 	w.WriteHeader(200)
 	w.Write([]byte("Hello World\n"))
 }
 
 func (s *HTTPTestSuite) TestHelloWorld(c *gc.C) {
-	s.Mux.Handle("/", &HelloHandler{})
+	s.Mux.GET("/", HelloHandler)
 	response, err := http.Get(s.Server.URL)
 	c.Check(err, gc.IsNil)
 	content, err := ioutil.ReadAll(response.Body)
@@ -49,7 +48,7 @@ func (s *HTTPTestSuite) TestHelloWorld(c *gc.C) {
 }
 
 func (s *HTTPSTestSuite) TestHelloWorldWithTLS(c *gc.C) {
-	s.Mux.Handle("/", &HelloHandler{})
+	s.Mux.GET("/", HelloHandler)
 	c.Check(s.Server.URL[:8], gc.Equals, "https://")
 	response, err := http.Get(s.Server.URL)
 	// Default http.Get fails because the cert is self-signed

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,40 @@
+box: golang
+
+build:
+  steps:
+    # Sets the go workspace and places you package
+    # at the right place in the workspace tree
+    - setup-go-workspace:
+        package-dir: github.com/joyent/gocommon
+
+    # Gets the dependencies
+    - script:
+        name: go get
+        code: |
+          go get -v -t ./...
+
+    # Build the project
+    - script:
+        name: go build
+        code: |
+          go build ./...
+
+    - script:
+        name: make a new key for testing
+        code: |
+          ssh-keygen -b 2048 \
+                     -C "Testing Key" \
+                     -f /root/.ssh/id_rsa \
+                     -t rsa \
+                     -P ""
+
+    # Test the project
+    - script:
+        name: go test
+        code: |
+          export KEY_ID=$(ssh-keygen -lf /root/.ssh/id_rsa | awk -F' ' '{print $2}' | cut -d':' -f2-)
+          export SDC_KEY_ID=${KEY_ID}
+          export MANTA_KEY_ID=${KEY_ID}
+          export SDC_URL=https://us-east-1.api.joyent.com
+          export MANTA_URL=https://us-east.manta.joyent.com
+          go test ./...


### PR DESCRIPTION
For https://github.com/joyent/gocommon/issues/10

As in [an issue with gomanta](https://github.com/joyent/gomanta/issues/7#issuecomment-260431734) the test suite was not updated with the new router that was added in https://github.com/joyent/gocommon/commit/f676d62ce82493bf5ccf3091010e986c4e271703. This makes sure we're using the same library in this test suite.

Additionally, in a previous commit (5642c3e) we accidentally removed the setup of the TLS test suite which is used to verify the client behavior on self-signed TLS cert. This restores the correct behavior by splitting out a second test suite.

cc @misterbisson 

Test run:

```
$ go test ./...
ok      github.com/joyent/gocommon      0.011s
ok      github.com/joyent/gocommon/client       0.830s
ok      github.com/joyent/gocommon/errors       0.007s
ok      github.com/joyent/gocommon/http 0.121s
?       github.com/joyent/gocommon/jpc  [no test files]
ok      github.com/joyent/gocommon/testing      0.079s
```

