### PR TITLE
use gopkg.in/check.v1

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -16,7 +16,7 @@ import (
 	joyenthttp "github.com/joyent/gocommon/http"
 	"github.com/joyent/gocommon/jpc"
 	"github.com/joyent/gosign/auth"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 	"net/http"
 	"testing"
 	"time"

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -11,7 +11,7 @@ package errors_test
 
 import (
 	"github.com/joyent/gocommon/errors"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 	"testing"
 )
 

--- a/gocommon_test.go
+++ b/gocommon_test.go
@@ -12,11 +12,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-
 package gocommon
 
 import (
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 	"testing"
 )
 

--- a/http/client.go
+++ b/http/client.go
@@ -346,7 +346,7 @@ func (c *Client) sendRateLimitedRequest(method, URL string, headers http.Header,
 			return nil, errors.Newf(err, "Resource limit exeeded at URL %s", URL)
 		}
 		if logger != nil {
-			logger.Println("Too many requests, retrying in %dms.", int(retryAfter*1000))
+			logger.Printf("Too many requests, retrying in %dms.", int(retryAfter*1000))
 		}
 		time.Sleep(time.Duration(retryAfter) * time.Second)
 	}

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 	"net/http"
 	"testing"
 

--- a/testing/httpsuite.go
+++ b/testing/httpsuite.go
@@ -7,7 +7,7 @@ package testing
 
 import (
 	"github.com/julienschmidt/httprouter"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 	"net/http"
 	"net/http/httptest"
 )

--- a/testing/httpsuite_test.go
+++ b/testing/httpsuite_test.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 	"net/http"
 	"net/url"
 	"reflect"

--- a/version_test.go
+++ b/version_test.go
@@ -15,7 +15,7 @@
 package gocommon
 
 import (
-	gc "launchpad.net/gocheck"
+	gc "gopkg.in/check.v1"
 )
 
 type VersionTestSuite struct {


### PR DESCRIPTION
The launchpad.net/gocheck import path is outdated
and doesn't work OK with Go module support, so use
the more recent (and compatible) gopkg.in/check.v1
import instead.

Also fix a bogus Println call reported by go vet too.